### PR TITLE
Fixes & Additional features

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ https://docs.ansible.com/ansible/latest/reference_appendices/config.html
 ```yaml
 plugin: dna_center
 host: 'dna-3-dnac.campus.wwtatc.local'
-validate_certs: 'no'
+validate_certs: false
 use_dnac_mgmt_int: false
 username: '{{ your_dnac_username }}'
 password: '{{ your_dnac_pwd }}'
+toplevel:
 ```
 
 **STEP 5.**  Execute the example below to test functionality

--- a/inventory_plugins/dna_center.yml
+++ b/inventory_plugins/dna_center.yml
@@ -1,6 +1,7 @@
 plugin: dna_center
 host: 'dna-3-dnac.campus.wwtatc.local'
-validate_certs: 'no'
+validate_certs: false
 use_dnac_mgmt_int: false
 username: 'admin'
 password: 'test1234'
+toplevel: 'dnac3'


### PR DESCRIPTION
* Cleanup special-character handling in DNAC hierarchy levels (area/site/buildings)
* validate_certs option was ignored before - fixed now
* Handle collisions if site/building have the same name (ansible groups do not accept this)
* Add new config option toplevel which allows to specificy the top-level group (=parent) within ansible (useful for multiple DNAC connections
* Added additional fields from DNAC (reachabilityStatus etc)